### PR TITLE
Fix calloc size parameters in test files.

### DIFF
--- a/tests/aring_1.c
+++ b/tests/aring_1.c
@@ -17,9 +17,9 @@ void * consumer(void * v);
 int main()
 {
 	pthread_t t;
-	a = calloc(1, sizeof a);
+	a = calloc(1, sizeof * a);
 	aring_init(a, SIZE);
-	sleepytime = calloc(1, sizeof sleepytime);
+	sleepytime = calloc(1, sizeof * sleepytime);
 	sleepytime->tv_nsec = NSLEEP;
 	pthread_create(&t, NULL, &consumer, NULL);
 	producer(NULL);

--- a/tests/aring_2048.c
+++ b/tests/aring_2048.c
@@ -17,9 +17,9 @@ void * consumer(void * v);
 int main()
 {
 	pthread_t t;
-	a = calloc(1, sizeof a);
+	a = calloc(1, sizeof * a);
 	aring_init(a, SIZE);
-	sleepytime = calloc(1, sizeof sleepytime);
+	sleepytime = calloc(1, sizeof * sleepytime);
 	sleepytime->tv_nsec = NSLEEP;
 	pthread_create(&t, NULL, &consumer, NULL);
 	producer(NULL);

--- a/tests/aring_64.c
+++ b/tests/aring_64.c
@@ -17,9 +17,9 @@ void * consumer(void * v);
 int main()
 {
 	pthread_t t;
-	a = calloc(1, sizeof a);
+	a = calloc(1, sizeof * a);
 	aring_init(a, SIZE);
-	sleepytime = calloc(1, sizeof sleepytime);
+	sleepytime = calloc(1, sizeof * sleepytime);
 	sleepytime->tv_nsec = NSLEEP;
 	pthread_create(&t, NULL, &consumer, NULL);
 	producer(NULL);

--- a/tests/aring_huge.c
+++ b/tests/aring_huge.c
@@ -17,9 +17,9 @@ void * consumer(void * v);
 int main()
 {
 	pthread_t t;
-	a = calloc(1, sizeof a);
+	a = calloc(1, sizeof * a);
 	aring_init(a, SIZE);
-	sleepytime = calloc(1, sizeof sleepytime);
+	sleepytime = calloc(1, sizeof * sleepytime);
 	sleepytime->tv_nsec = NSLEEP;
 	pthread_create(&t, NULL, &consumer, NULL);
 	producer(NULL);


### PR DESCRIPTION
The test files did not allocate space for the actual global structs `atomic_ring` and `timespec`. This pull request fixes this, as the test files were crashing on my Windows machine. Incidentally, the files would not crash in mingw-w64 gdb, and presumably on *nix; I'm guessing the pointers returned from malloc are always less-finely grained than 16-bytes in both environments.
